### PR TITLE
Added shutdown with Prepare stage

### DIFF
--- a/CSSS/Bootstrap.cs
+++ b/CSSS/Bootstrap.cs
@@ -142,6 +142,11 @@ namespace CSSS
                     // *******************
                     // Optional arguments
                     // *******************
+                    case "shutdown":
+                        config.CSSSProgramMode |= Config.CSSSModes.Shutdown;
+                        canStart = true;
+                        break;
+
                     case "h":
                     case "help":
                     default:
@@ -186,12 +191,13 @@ namespace CSSS
 
             // Argument combinations to pass
             Console.WriteLine("Usage:");
-            Console.WriteLine("  CSSS.exe -c | -o | -p | -s | [-h] | [-m]");
+            Console.WriteLine("  CSSS.exe -c | -o | -p | -s | [--shutdown] | [-h] | [-m]");
             Console.WriteLine();
             Console.WriteLine("Examples:");
             Console.WriteLine("  CSSS.exe -c");
             Console.WriteLine("  CSSS.exe -o -m");
             Console.WriteLine("  CSSS.exe -p");
+            Console.WriteLine("  CSSS.exe -p --shutdown");
             Console.WriteLine("  CSSS.exe -s");
             Console.WriteLine("  CSSS.exe -h");
 
@@ -231,6 +237,9 @@ namespace CSSS
             Console.Write("  -h, --help:".PadRight(rightPadding));
             Console.WriteLine("Shows this help message");
 
+            // Shutdown the computer
+            Console.Write("  --shutdown:".PadRight(rightPadding));
+            Console.WriteLine("Shuts down the computer. Should be used in conjunction with -p/--prepare to aid imaging.");
 
             // *******************
             // Developer arguments

--- a/CSSS/Bootstrap.cs
+++ b/CSSS/Bootstrap.cs
@@ -58,15 +58,15 @@ namespace CSSS
         /// image is released, to prevent any cheating by competitors
         /// 
         /// Valid required arguments that CSSS accepts are:
-        ///   * -c, --check:   Checks the config files for any problems
-        ///   * -o, --observe: Observes CSSS running before preparing it (implies 'c')
-        ///   * -p, --prepare: Prepares CSSS ready for image release (implies '-c')
-        ///   * -s, --start:   Starts the scoring system
-        ///   * -h, --help:    Shows the program usage
+        ///   * -c, --check:    Checks the config files for any problems
+        ///   * -o, --observe:  Observes CSSS running before preparing it (implies '-c')
+        ///   * -p, --prepare:  Prepares CSSS ready for image release (implies '-c')
+        ///   * -s, --start:    Starts the scoring system
+        ///   * -h, --help:     Shows the program usage
         /// 
         /// Additional arguments that can be passed to CSSS are:
+        ///   * --shutdown:     Shuts down the computer after preparing CSSS (used with '-p')
         ///   * -m, --multiple: Allows multiple instances of CSSS to run concurently
-        /// 
         /// These arguments have been chosen to spell 'COPS', as competitors
         /// are 'policing' the security of the computer
         /// 

--- a/CSSS/Bootstrap.cs
+++ b/CSSS/Bootstrap.cs
@@ -238,7 +238,7 @@ namespace CSSS
             Console.WriteLine("Shows this help message");
 
             // Shutdown the computer
-            Console.Write("  --shutdown".PadRight(RIGHT_PADDING));
+            Console.Write("  --shutdown:".PadRight(RIGHT_PADDING));
             Console.WriteLine("Shuts down the computer");
             Console.Write("".PadRight(RIGHT_PADDING));
             Console.WriteLine("Can be used with -p / --prepare to aid image capture");

--- a/CSSS/Bootstrap.cs
+++ b/CSSS/Bootstrap.cs
@@ -191,7 +191,7 @@ namespace CSSS
 
             // Argument combinations to pass
             Console.WriteLine("Usage:");
-            Console.WriteLine("  CSSS.exe -c | -o | -p | -s [--shutdown] | [-h] | [-m]");
+            Console.WriteLine("  CSSS.exe -c | -o | -p [--shutdown] | -s | [-h] | [-m]");
             Console.WriteLine();
             Console.WriteLine("Examples:");
             Console.WriteLine("  CSSS.exe -c");

--- a/CSSS/Bootstrap.cs
+++ b/CSSS/Bootstrap.cs
@@ -174,7 +174,7 @@ namespace CSSS
         /// </summary>
         private void ShowUsage()
         {
-            int rightPadding = 18;
+            const int RIGHT_PADDING = 18;
 
             // Preventing the usage screen being shown multiple times if
             // the "-h" argument is passed more than once to CSSS, or a
@@ -191,7 +191,7 @@ namespace CSSS
 
             // Argument combinations to pass
             Console.WriteLine("Usage:");
-            Console.WriteLine("  CSSS.exe -c | -o | -p | -s | [--shutdown] | [-h] | [-m]");
+            Console.WriteLine("  CSSS.exe -c | -o | -p | -s [--shutdown] | [-h] | [-m]");
             Console.WriteLine();
             Console.WriteLine("Examples:");
             Console.WriteLine("  CSSS.exe -c");
@@ -210,19 +210,19 @@ namespace CSSS
             Console.WriteLine("Required arguments (at least one is needed):");
 
             // Check config files
-            Console.Write("  -c, --check:".PadRight(rightPadding));
+            Console.Write("  -c, --check:".PadRight(RIGHT_PADDING));
             Console.WriteLine("Checks the config files for any problems");
 
             // Observe running
-            Console.Write("  -o, --observe:".PadRight(rightPadding));
+            Console.Write("  -o, --observe:".PadRight(RIGHT_PADDING));
             Console.WriteLine("Observes CSSS running before preparing it (implies '-c')");
 
             // Prepare CSSS
-            Console.Write("  -p, --prepare:".PadRight(rightPadding));
+            Console.Write("  -p, --prepare:".PadRight(RIGHT_PADDING));
             Console.WriteLine("Prepares CSSS ready for image release (implies '-c')");
 
             // Start scoring system
-            Console.Write("  -s, --start:".PadRight(rightPadding));
+            Console.Write("  -s, --start:".PadRight(RIGHT_PADDING));
             Console.WriteLine("Starts the scoring system");
 
 
@@ -234,12 +234,14 @@ namespace CSSS
             Console.WriteLine("Optional arguments:");
 
             // Help
-            Console.Write("  -h, --help:".PadRight(rightPadding));
+            Console.Write("  -h, --help:".PadRight(RIGHT_PADDING));
             Console.WriteLine("Shows this help message");
 
             // Shutdown the computer
-            Console.Write("  --shutdown:".PadRight(rightPadding));
-            Console.WriteLine("Shuts down the computer. Should be used in conjunction with -p/--prepare to aid imaging.");
+            Console.Write("  --shutdown".PadRight(RIGHT_PADDING));
+            Console.WriteLine("Shuts down the computer");
+            Console.Write("".PadRight(RIGHT_PADDING));
+            Console.WriteLine("Can be used with -p / --prepare to aid image capture");
 
             // *******************
             // Developer arguments
@@ -249,7 +251,7 @@ namespace CSSS
             Console.WriteLine("Developer arguments (all optional):");
 
             // Multipile instances allowed to concurrently run
-            Console.Write("  -m, --multiple:".PadRight(rightPadding));
+            Console.Write("  -m, --multiple:".PadRight(RIGHT_PADDING));
             Console.WriteLine("Allows multiple instances of CSSS to run concurently");
         }
     }

--- a/CSSS/CSSS.csproj
+++ b/CSSS/CSSS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -26,17 +26,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="HtmlAgilityPack, Version=1.11.8.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\packages\HtmlAgilityPack.1.11.8\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.16.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.11.16\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Win32.TaskScheduler, Version=2.8.12.0, Culture=neutral, PublicKeyToken=c416bc1b32d97233, processorArchitecture=MSIL">
-      <HintPath>..\packages\TaskScheduler.2.8.12\lib\net40\Microsoft.Win32.TaskScheduler.dll</HintPath>
+    <Reference Include="Microsoft.Win32.TaskScheduler, Version=2.8.16.0, Culture=neutral, PublicKeyToken=c416bc1b32d97233, processorArchitecture=MSIL">
+      <HintPath>..\packages\TaskScheduler.2.8.16\lib\net40\Microsoft.Win32.TaskScheduler.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.6.5\lib\net40-client\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.6.7\lib\net40-client\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
@@ -89,8 +89,6 @@
       <Name>CSSSLauncher</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="IssueChecks\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CSSS/Kernel.cs
+++ b/CSSS/Kernel.cs
@@ -101,7 +101,6 @@ namespace CSSS
         {
             logger.Debug("Performing kernel tasks");
             bool shouldExit = false;
-            bool shouldShutdown = false;
 
             // Seeing if the check files need to be linted
             if (config.CSSSProgramMode.HasFlag(Config.CSSSModes.Check))
@@ -158,10 +157,6 @@ namespace CSSS
                 // so return 'true' from this function to let the
                 // calling main run loop know it can exit
                 shouldExit = true;
-                // As the -p flag should also shutdown the OS so
-                // that the machine can be imaged, we should set
-                // the shutdown flag to true
-                shouldShutdown = true;
             }
 
             // Seeing if CSSS should start and run normally
@@ -172,7 +167,7 @@ namespace CSSS
             }
 
             // If we should shutdown
-            if (shouldShutdown)
+            if (config.CSSSProgramMode.HasFlag(Config.CSSSModes.Shutdown))
             {
                 // Run the shutdown command
                 var process = new System.Diagnostics.Process();
@@ -180,20 +175,26 @@ namespace CSSS
                 switch (config.operatingSystemType)
                 {
                     case Config.OperatingSystemType.WinNT:
-                        // On Windows, we can specify the seconds
-                        // to delay the shutdown :D
-                        // So we shutdown in 15 seconds (should be suffficient time)
-                        process.StartInfo.Arguments = "-s -t 15";
+                        logger.Info("Operating System detected as WinNT - shutting down computer in 5 seconds");
+                        // On Windows, we can specify the seconds to delay the shutdown
+                        // So we shutdown in 15 seconds 
+                        // The logic behind this is that shutting down the program immediately
+                        // may cause issues if there is a longer lasting process and allows
+                        // time for the program to gracefully exit without being terminated
+                        // as the computer shutsdown
+                        process.StartInfo.Arguments = "-s -t 5";
                         break;
                     case Config.OperatingSystemType.Linux:
-                        // Linux doesn't let you specify seconds... >:(
+                        logger.Info("Operating System detected as WinNT - shutting down computer in 1 minute");
+                        // Linux doesn't let you specify seconds so it defaults to 1 minute
+                        // See above command for logic on shutdown
                         process.StartInfo.Arguments = "-h +1";
                         break;
                     default:
-                        logger.Warn("Unknown OS specified in Shutdown - this shouldn't happen");
+                        logger.Warn("Unknown OS specified in Shutdown - you will need to do this manually");
                         break;
                 }
-                // Execute
+
                 process.Start();
             }
 

--- a/CSSS/Kernel.cs
+++ b/CSSS/Kernel.cs
@@ -157,6 +157,43 @@ namespace CSSS
                 // so return 'true' from this function to let the
                 // calling main run loop know it can exit
                 shouldExit = true;
+
+                // If we should shutdown
+                if (config.CSSSProgramMode.HasFlag(Config.CSSSModes.Shutdown))
+                {
+                    // Run the shutdown command
+                    var process = new System.Diagnostics.Process();
+                    process.StartInfo.FileName = "shutdown";
+
+                    Console.WriteLine("Shutting down computer in 1 minute for image capture");
+
+                    logger.Info("Attempting to shut down the computer in 1 minute");
+                    switch (config.operatingSystemType)
+                    {
+                        case Config.OperatingSystemType.WinNT:
+                            logger.Info("Operating System detected as WinNT - shutting down computer in 5 seconds");
+                            // On Windows, we can specify the seconds to delay the shutdown
+                            // So we shutdown in 60 seconds 
+                            // The logic behind this is that shutting down the program immediately
+                            // may cause issues if there is a longer lasting process and allows
+                            // time for the program to gracefully exit without being terminated
+                            // as the computer shutsdown
+                            process.StartInfo.Arguments = "-s -t 60";
+                            break;
+                        case Config.OperatingSystemType.Linux:
+                            
+                            // Linux doesn't let you specify seconds so it defaults to 1 minute
+                            // See above command for logic on shutdown
+                            process.StartInfo.Arguments = "-h +1";
+                            break;
+                        default:
+                            logger.Warn("Unable to shutdown computer - you will need to do this manually");
+                            break;
+                    }
+
+                    process.Start();
+                    process.WaitForExit();
+                }
             }
 
             // Seeing if CSSS should start and run normally
@@ -164,38 +201,6 @@ namespace CSSS
             {
                 logger.Info("Running CSSS normally");
                 PerformIssueCheckTasks();
-            }
-
-            // If we should shutdown
-            if (config.CSSSProgramMode.HasFlag(Config.CSSSModes.Shutdown))
-            {
-                // Run the shutdown command
-                var process = new System.Diagnostics.Process();
-                process.StartInfo.FileName = "shutdown";
-                switch (config.operatingSystemType)
-                {
-                    case Config.OperatingSystemType.WinNT:
-                        logger.Info("Operating System detected as WinNT - shutting down computer in 5 seconds");
-                        // On Windows, we can specify the seconds to delay the shutdown
-                        // So we shutdown in 15 seconds 
-                        // The logic behind this is that shutting down the program immediately
-                        // may cause issues if there is a longer lasting process and allows
-                        // time for the program to gracefully exit without being terminated
-                        // as the computer shutsdown
-                        process.StartInfo.Arguments = "-s -t 5";
-                        break;
-                    case Config.OperatingSystemType.Linux:
-                        logger.Info("Operating System detected as WinNT - shutting down computer in 1 minute");
-                        // Linux doesn't let you specify seconds so it defaults to 1 minute
-                        // See above command for logic on shutdown
-                        process.StartInfo.Arguments = "-h +1";
-                        break;
-                    default:
-                        logger.Warn("Unknown OS specified in Shutdown - you will need to do this manually");
-                        break;
-                }
-
-                process.Start();
             }
 
             logger.Debug("CSSS should exit: {0}", shouldExit);

--- a/CSSS/Kernel.cs
+++ b/CSSS/Kernel.cs
@@ -165,25 +165,16 @@ namespace CSSS
                     var process = new System.Diagnostics.Process();
                     process.StartInfo.FileName = "shutdown";
 
-                    Console.WriteLine("Shutting down computer in 1 minute for image capture");
-
+                    // The logic behind a minute delay before shutting down is to allow
+                    // CSSS to finish running and gracefully exit, rather than being
+                    // terminated as the computer shuts down
                     logger.Info("Attempting to shut down the computer in 1 minute");
                     switch (config.operatingSystemType)
                     {
                         case Config.OperatingSystemType.WinNT:
-                            logger.Info("Operating System detected as WinNT - shutting down computer in 5 seconds");
-                            // On Windows, we can specify the seconds to delay the shutdown
-                            // So we shutdown in 60 seconds 
-                            // The logic behind this is that shutting down the program immediately
-                            // may cause issues if there is a longer lasting process and allows
-                            // time for the program to gracefully exit without being terminated
-                            // as the computer shutsdown
                             process.StartInfo.Arguments = "-s -t 60";
                             break;
                         case Config.OperatingSystemType.Linux:
-                            
-                            // Linux doesn't let you specify seconds so it defaults to 1 minute
-                            // See above command for logic on shutdown
                             process.StartInfo.Arguments = "-h +1";
                             break;
                         default:

--- a/CSSS/packages.config
+++ b/CSSS/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="HtmlAgilityPack" version="1.11.8" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.16" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net40" />
-  <package id="NLog" version="4.6.5" targetFramework="net40" />
-  <package id="TaskScheduler" version="2.8.12" targetFramework="net40" />
+  <package id="NLog" version="4.6.7" targetFramework="net40" />
+  <package id="TaskScheduler" version="2.8.16" targetFramework="net40" />
 </packages>

--- a/CSSSCheckerEngine/CSSSCheckerEngine.csproj
+++ b/CSSSCheckerEngine/CSSSCheckerEngine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -28,14 +28,20 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.6.7\lib\net40-client\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.6.5\lib\net40-client\NLog.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CheckerEngine.cs" />
@@ -52,19 +58,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Checker\" />
-    <Folder Include="Checker\System\" />
-    <Folder Include="OS\" />
-    <Folder Include="OS\Linux\" />
-    <Folder Include="OS\Linux\System\" />
-    <Folder Include="OS\WinNT\" />
-    <Folder Include="OS\WinNT\System\" />
-    <Folder Include="CheckAPI\" />
-    <Folder Include="CheckAPI\System\" />
-    <Folder Include="Issues\" />
-    <Folder Include="Issues\System\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\CSSSConfig\CSSSConfig.csproj">
       <Project>{2B005BD2-677F-4646-BB17-673AD50DF07D}</Project>

--- a/CSSSCheckerEngine/packages.config
+++ b/CSSSCheckerEngine/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net40" />
-  <package id="NLog" version="4.6.5" targetFramework="net40" />
+  <package id="NLog" version="4.6.7" targetFramework="net40" />
 </packages>

--- a/CSSSConfig/Config.cs
+++ b/CSSSConfig/Config.cs
@@ -78,7 +78,8 @@ namespace CSSSConfig
             Prepare = 0x2,
             Observe = 0x4,
             Start = 0x8,
-            MultipleInstances = 0x10
+            MultipleInstances = 0x10,
+            Shutdown = 0x20
         }
 
         /// <summary>

--- a/CSSSNotifications/CSSSNotifications.csproj
+++ b/CSSSNotifications/CSSSNotifications.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -28,12 +28,19 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.6.7\lib\net40-client\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Drawing" />
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.6.5\lib\net40-client\NLog.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -54,10 +61,6 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="OS\" />
-    <Folder Include="OS\Linux\" />
-    <Folder Include="OS\WinNT\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CSSSNotifications/packages.config
+++ b/CSSSNotifications/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.6.5" targetFramework="net40" />
+  <package id="NLog" version="4.6.7" targetFramework="net40" />
 </packages>

--- a/CSSSTests/packages.config
+++ b/CSSSTests/packages.config
@@ -6,6 +6,6 @@
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net40" />
   <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net40" />
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net40" />
-  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.6" targetFramework="net40" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.7" targetFramework="net40" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net40" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ These are the tasks planned for each release version. Please note that these can
     * ~~[Windows shortcut](http://stackoverflow.com/a/19914018) in [Programdata startup folder](https://www.kiloroot.com/all-users-or-common-startup-folder-locations-launch-programs-at-window-login-windows-server-2008-r2-2012-2012-r2/)~~
     * ~~[Linux](http://raspberrypi.stackexchange.com/a/5159)~~
   * Email list of issues to be fixed when '--email' argument is passed
-  * Shutdown the computer to allow an image to be taken
+  * ~~Shutdown the computer to allow an image to be taken~~
 * Comment ~~and coding style~~ tidy-up
 
 ### Version 0.4

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Before CSSS will run, the following additional programs need to be installed ont
 Double-clicking on CSSS will cause it to quickly show the usage window, then close itself. This is by design. To run CSSS properly, a number of arguments need to be passed to the program, which are:
 ```
 Usage:
-  CSSS.exe -c | -o | -p | -s | [-h] | [-m]
+  CSSS.exe -c | -o | -p [--shutdown] | -s | [-h] | [-m]
 
 Examples:
   CSSS.exe -c
   CSSS.exe -o -m
   CSSS.exe -p
+  CSSS.exe -p --shutdown
   CSSS.exe -s
   CSSS.exe -h
 
@@ -55,6 +56,8 @@ Required arguments (at least one is needed):
 
 Optional arguments:
   -h, --help:     Shows this help message
+  --shutdown:     Shuts down the computer
+                  Can be used with -p / --prepare to aid image capture
 
 
 Developer arguments (all optional):


### PR DESCRIPTION
When using the -p argument, CSSS now shutsdown the computer in 15 seconds on Windows and a minute on Linux